### PR TITLE
Use redis-py instead of aioredis-py

### DIFF
--- a/docs/cores/installation.md
+++ b/docs/cores/installation.md
@@ -26,7 +26,7 @@ Depending on the need, installation of extras may be needed:
 
 ```shell
 pip install pyot[diskcache]     # installs: ["diskcache>=5.1", "asgiref>=3.2"]
-pip install pyot[redis]         # installs: ["aioredis[hiredis]>=2.0"]
+pip install pyot[redis]         # installs: ["redis[hiredis]>=4.5.0"]
 pip install pyot[mongodb]       # installs: ["motor>=2.3"]
 pip install pyot[test]          # installs: ["typeguard>=2.13"] + all above
 ```

--- a/docs/stores/rediscache.md
+++ b/docs/stores/rediscache.md
@@ -3,7 +3,7 @@
 - Type: Cache
 - Description: Uses Redis servers as Caches. This cache provides similar speeds to Omnistone while preserving data even if the program is down.
 
-This Cache is built on top of Async Python integration of [redis](https://github.com/aio-libs/aioredis-py).
+This Cache is built on top of Async Python integration of [redis](https://github.com/redis/redis-py).
 
 An extra installation is required: `pip install pyot[redis]`
 

--- a/pyot/limiters/redis.py
+++ b/pyot/limiters/redis.py
@@ -2,7 +2,7 @@ from time import time
 from typing import Dict, List, Union
 
 from aiohttp import ClientResponse
-import aioredis
+import redis.asyncio as aioredis
 
 from pyot.core.resources import ResourceTemplate
 

--- a/pyot/stores/rediscache.py
+++ b/pyot/stores/rediscache.py
@@ -1,5 +1,5 @@
 from typing import Any
-import aioredis
+import redis.asyncio as aioredis
 import pickle
 
 from pyot.core.exceptions import NotFound

--- a/setup.py
+++ b/setup.py
@@ -20,9 +20,9 @@ install_requires = [
 
 extras_require = {
     "diskcache": ["diskcache>=5.1", "asgiref>=3.2"],
-    "redis": ["aioredis[hiredis]>=2.0"],
+    "redis": ["redis[hiredis]>=4.5.0"],
     "mongodb": ["motor>=2.3"],
-    "test": ["typeguard>=2.13", "aioredis[hiredis]>=2.0", "motor>=2.3", "diskcache>=5.1", "asgiref>=3.2"],
+    "test": ["typeguard>=2.13", "redis[hiredis]>=4.5.0", "motor>=2.3", "diskcache>=5.1", "asgiref>=3.2"],
 }
 
 


### PR DESCRIPTION
aioredis-py development and PyPI packages have been moved to redis-py.
This allows Pyot to run on Python 3.11 with Redis cache and limiter